### PR TITLE
Replay an aggregates all events throws argumenterror

### DIFF
--- a/lib/fable/events.ex
+++ b/lib/fable/events.ex
@@ -193,7 +193,19 @@ defmodule Fable.Events do
     empty_last_event_id = dynamic([agg], is_nil(agg.last_event_id))
 
     prev_agg_and_db_last_event_id_match =
-      dynamic([agg], agg.last_event_id == ^prev_agg.last_event_id)
+      case prev_agg.last_event_id do
+        nil ->
+          dynamic(
+            [agg],
+            is_nil(agg.last_event_id) == is_nil(^prev_agg.last_event_id)
+          )
+
+        _ ->
+          dynamic(
+            [agg],
+            agg.last_event_id == ^prev_agg.last_event_id
+          )
+      end
 
     # Must those actually be update? Seems like it's already correct
     # event_id_matches_last_event_id = dynamic([m], m.last_event_id == ^event.id)

--- a/lib/fable/events.ex
+++ b/lib/fable/events.ex
@@ -192,27 +192,24 @@ defmodule Fable.Events do
     aggregate_id_matches = dynamic([agg], agg.id == ^id)
     empty_last_event_id = dynamic([agg], is_nil(agg.last_event_id))
 
-    prev_agg_and_db_last_event_id_match =
-      case prev_agg.last_event_id do
-        nil ->
-          dynamic(
-            [agg],
-            is_nil(agg.last_event_id) == is_nil(^prev_agg.last_event_id)
-          )
+    case prev_agg.last_event_id do
+      nil ->
+        dynamic(^aggregate_id_matches and ^empty_last_event_id)
 
-        _ ->
+      _ ->
+        prev_agg_and_db_last_event_id_match =
           dynamic(
             [agg],
             agg.last_event_id == ^prev_agg.last_event_id
           )
-      end
+
+        dynamic(
+          ^aggregate_id_matches and (^empty_last_event_id or ^prev_agg_and_db_last_event_id_match)
+        )
+    end
 
     # Must those actually be update? Seems like it's already correct
     # event_id_matches_last_event_id = dynamic([m], m.last_event_id == ^event.id)
-
-    dynamic(
-      ^aggregate_id_matches and (^empty_last_event_id or ^prev_agg_and_db_last_event_id_match)
-    )
   end
 
   @doc false


### PR DESCRIPTION
Not sure if I'm doing something wrong in my setup but when trying to replay an aggregate I end up in an error down in events.ex.

When prev_agg has a last_event_id that is nil Ecto throws 
```
** (ArgumentError) comparison with nil is forbidden as it is unsafe. If you want to check if a value is nil, use is_nil/1 instead
```
