### PR TITLE
Allow opting out of included functions from use Fable.Events

### DIFF
--- a/lib/fable/events.ex
+++ b/lib/fable/events.ex
@@ -93,6 +93,7 @@ defmodule Fable.Events do
   defmacro __using__(opts) do
     quote do
       opts = unquote(opts)
+      {except, opts} = Keyword.pop(opts, :except, [])
       @__fable_config__ Fable.Config.new(__MODULE__, opts)
       @behaviour unquote(__MODULE__)
       if @__fable_config__.router == __MODULE__ do
@@ -121,20 +122,28 @@ defmodule Fable.Events do
         Supervisor.start_link(Fable, __fable_config__(), [])
       end
 
-      def log(schema) do
-        unquote(__MODULE__).log(@__fable_config__, schema)
+      unless Enum.member?(except, :log) do
+        def log(schema) do
+          unquote(__MODULE__).log(@__fable_config__, schema)
+        end
       end
 
-      def replay(agg) do
-        unquote(__MODULE__).replay(@__fable_config__, agg)
+      unless Enum.member?(except, :replay) do
+        def replay(agg) do
+          unquote(__MODULE__).replay(@__fable_config__, agg)
+        end
       end
 
-      def emit(aggregate, fun, opts \\ []) do
-        unquote(__MODULE__).emit(@__fable_config__, aggregate, fun, opts)
+      unless Enum.member?(except, :emit) do
+        def emit(aggregate, fun, opts \\ []) do
+          unquote(__MODULE__).emit(@__fable_config__, aggregate, fun, opts)
+        end
       end
 
-      def emit(multi, aggregate, name, fun, opts \\ []) do
-        unquote(__MODULE__).emit(@__fable_config__, multi, aggregate, name, fun, opts)
+      unless Enum.member?(except, :emit) do
+        def emit(multi, aggregate, name, fun, opts \\ []) do
+          unquote(__MODULE__).emit(@__fable_config__, multi, aggregate, name, fun, opts)
+        end
       end
 
       def unconditionally_emit(aggregate, event_or_events, opts \\ []) do

--- a/lib/fable/events.ex
+++ b/lib/fable/events.ex
@@ -93,7 +93,6 @@ defmodule Fable.Events do
   defmacro __using__(opts) do
     quote do
       opts = unquote(opts)
-      {except, opts} = Keyword.pop(opts, :except, [])
       @__fable_config__ Fable.Config.new(__MODULE__, opts)
       @behaviour unquote(__MODULE__)
       if @__fable_config__.router == __MODULE__ do
@@ -122,28 +121,20 @@ defmodule Fable.Events do
         Supervisor.start_link(Fable, __fable_config__(), [])
       end
 
-      unless Enum.member?(except, :log) do
-        def log(schema) do
-          unquote(__MODULE__).log(@__fable_config__, schema)
-        end
+      def log(schema) do
+        unquote(__MODULE__).log(@__fable_config__, schema)
       end
 
-      unless Enum.member?(except, :replay) do
-        def replay(agg) do
-          unquote(__MODULE__).replay(@__fable_config__, agg)
-        end
+      def replay(agg) do
+        unquote(__MODULE__).replay(@__fable_config__, agg)
       end
 
-      unless Enum.member?(except, :emit) do
-        def emit(aggregate, fun, opts \\ []) do
-          unquote(__MODULE__).emit(@__fable_config__, aggregate, fun, opts)
-        end
+      def emit(aggregate, fun, opts \\ []) do
+        unquote(__MODULE__).emit(@__fable_config__, aggregate, fun, opts)
       end
 
-      unless Enum.member?(except, :emit) do
-        def emit(multi, aggregate, name, fun, opts \\ []) do
-          unquote(__MODULE__).emit(@__fable_config__, multi, aggregate, name, fun, opts)
-        end
+      def emit(multi, aggregate, name, fun, opts \\ []) do
+        unquote(__MODULE__).emit(@__fable_config__, multi, aggregate, name, fun, opts)
       end
 
       def unconditionally_emit(aggregate, event_or_events, opts \\ []) do
@@ -154,6 +145,8 @@ defmodule Fable.Events do
           opts
         )
       end
+
+      defoverridable emit: 3, emit: 4, emit: 5
     end
   end
 


### PR DESCRIPTION
I have a situation where I'd like to have my own implementation of `emit` that enforces some meta-data (such as the current user performing a command).

In order to enforce this throughout the application I don't want Fable's default implementation of emit, but rather have my own which delegates to `Fable.Events.emit(__fable_config__(), ...)`.

This adds the possibility to exclude functions you don't want when doing `use Fable.Events`.