### PR TITLE
Fix `@spec` on emit

### DIFF
--- a/lib/fable/events.ex
+++ b/lib/fable/events.ex
@@ -62,7 +62,9 @@ defmodule Fable.Events do
 
   """
   @type event_or_events :: Fable.Event.t() | [Fable.Event.t()]
-  @type emit_callback :: (Ecto.Schema.t(), Ecto.Repo.t(), Ecto.Multi.changes() -> event_or_events)
+  @type emit_callback ::
+          (Ecto.Schema.t(), Ecto.Repo.t() -> event_or_events())
+          | (Ecto.Schema.t(), Ecto.Repo.t(), Ecto.Multi.changes() -> event_or_events())
   @type transation_fun :: (Ecto.Repo.t() -> any())
   @type handler ::
           (Fable.aggregate(), Fable.Event.t() -> {:ok, Fable.aggregate()} | {:error, term})


### PR DESCRIPTION
The `@type emit_callback` didn't have a 2-arity clause even though it supports a 2-arity callback. This PR adds that plus some minor stuff added by the formatter (then me).